### PR TITLE
Raise nicer error messages for API errors

### DIFF
--- a/ibis_datasette/core.py
+++ b/ibis_datasette/core.py
@@ -37,7 +37,10 @@ class _Client:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
-                raise ValueError(f"{url!r} is not a valid datasette URL") from exc
+                raise ValueError(f"{url!r} is not a valid datasette URL") from None
+            elif exc.response.status_code == 400:
+                json = exc.response.json()
+                raise ValueError(json["error"]) from None
             raise
         return resp
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -148,3 +148,9 @@ def test_string_query_parameters(url):
     con = ibis.datasette.connect(url)
     t1 = con.tables.table1
     assert t1.filter(t1.col2 == "alice").count().execute()
+
+
+def test_api_error_raised(url):
+    con = ibis.datasette.connect(url)
+    with pytest.raises(ValueError, match="missing"):
+        con.raw_sql("SELECT * FROM missing")


### PR DESCRIPTION
Sometimes datasette returns an error message as part of the JSON
payload. In this case, we re-raise the error message to the user.