### PR TITLE
Fix handling of many query parameters

### DIFF
--- a/ibis_datasette/core.py
+++ b/ibis_datasette/core.py
@@ -114,7 +114,11 @@ class Cursor:
                     "qmark (?) style parametrized queries are not supported"
                 )
             else:
-                for k, v in parameters.items():
+                # XXX: Traverse in reverse order to ensure replacements don't
+                # ever conflict (if we replace param_2 before param_20, we can
+                # end up accidentally overwriting param_20). All of this is bad
+                # and hacky.
+                for k, v in sorted(parameters.items(), reverse=True):
                     if isinstance(v, bool):
                         v = int(v)
                     if isinstance(v, (int, float)):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,14 @@
+import functools
+import operator
 import random
 import sqlite3
 import string
 import subprocess
 import time
 
-import ibis
 import pytest
+import ibis
+from ibis import _
 
 
 def randstr():
@@ -142,6 +145,15 @@ def test_numeric_query_parameters(url, bound):
     query = t1.group_by("col2").count().filter(lambda _: _["count"] > bound)
     out = query.execute()
     assert len(out)  # out is empty if bound interpreted as string
+
+
+def test_many_query_parameters(url):
+    con = ibis.datasette.connect(url)
+    query = con.tables.table1.filter(
+        functools.reduce(operator.or_, (_.col3 == x for x in range(30)))
+    ).col3.nunique()
+    out = query.execute()
+    assert out == 30
 
 
 def test_string_query_parameters(url):


### PR DESCRIPTION
Previously the hacky parameter substitution routine we use could
potentially clobber parameters starting with the same prefix, which
happens if you have 10 or more numeric query parameters. `param_1` and
`param_10` both start with the same prefix, but `param_1` is replaced
first, clobbering `param_10` accidentally.

We now replace parameters in reverse order, preventing this issue.